### PR TITLE
Fix check_eq when comparing values (no json data)

### DIFF
--- a/api-test.sh
+++ b/api-test.sh
@@ -386,7 +386,7 @@ has_key() {
 
 check_eq() {
   tput cuf 6
-  local type=$(jq -r -c --argjson a "$1" -n '$a|type' 2&>/dev/null)
+  local type=$(jq -r -c --argjson a "$1" -n '$a|type' 2>/dev/null)
   local check
   if [[ $type == "object" || $type == "array" ]]; then
     check=$(jq -c --argjson a "$1" --argjson b "$2" -n 'def post_recurse(f): def r: (f | select(. != null) | r), .; r; def post_recurse: post_recurse(.[]?); ($a | (post_recurse | arrays) |= sort) as $a | ($b | (post_recurse | arrays) |= sort) as $b | $a == $b')

--- a/api-test.sh
+++ b/api-test.sh
@@ -386,12 +386,18 @@ has_key() {
 
 check_eq() {
   tput cuf 6
-  local type=$(jq -r -c --argjson a "$1" -n '$a|type')
+  local type=$(jq -r -c --argjson a "$1" -n '$a|type' 2&>/dev/null)
   local check
   if [[ $type == "object" || $type == "array" ]]; then
     check=$(jq -c --argjson a "$1" --argjson b "$2" -n 'def post_recurse(f): def r: (f | select(. != null) | r), .; r; def post_recurse: post_recurse(.[]?); ($a | (post_recurse | arrays) |= sort) as $a | ($b | (post_recurse | arrays) |= sort) as $b | $a == $b')
-  else
+  elif [[ $type == "number" || $type == "boolean" || $type == "null" || $type == "string" ]]; then
     check=$(jq -c --argjson a "$1" --argjson b "$2" -n '$a == $b')
+  else
+    if [[ $1 == $2 ]]; then
+      check="true"
+    else
+      check="false"
+    fi
   fi
   if [[ $check == "true" ]]; then
     echo "${GREEN}${BOLD}Check Passed${RESET}"


### PR DESCRIPTION
## Issue
 https://github.com/subeshb1/api-test/issues/27

## Description/Summary
The goal was to compare values out of a json array:
example data:
```
[
    {
        "key": "value",
        "foo": "bar",
        "status": "ASTATUS"
    }
]
```
example test case:
```   
 ...
    "testCases": {
        "get_status": {
            "path": "/programs/",
            "method": "GET",
            "description": "GET /programs",
            "expect": {
                "body": {
                    "path_eq": {
                        "[0].status": "MYSTATUS"
                    }
                }
            }
        }
    }
```
This causes 'check_eq' to compare "ASTATUS" (from the data) with
"MYSTATUS" from the test description. This is what I want.
However the given arguements are not json data, and jq fails to retrieve
its' type and eventually fails to make a valid comparison.

First off all the type determination is expected to fail, which is
hidden with the redirection of stderr.

The actual type-comparisons are extended with all recognized types, and
everything else is just compared as a string.